### PR TITLE
Add Vite proxy configuration for frontend module

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,4 +4,12 @@ import react from "@vitejs/plugin-react";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+      host: true,
+      proxy: {
+          '/api': {
+              target: 'http://localhost:8080'
+          }
+      }
+  },
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,11 +5,11 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   plugins: [react()],
   server: {
-      host: true,
-      proxy: {
-          '/api': {
-              target: 'http://localhost:8080'
-          }
-      }
+    host: true,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+      },
+    },
   },
 });


### PR DESCRIPTION
Using Vite Proxy is a default way to connect frontend and backend with avoiding any problems with CORS