### PR TITLE
кодировка UTF-8 в тестах

### DIFF
--- a/src/test/java/io/hexlet/blog/controller/api/PostsCommentsControllerTest.java
+++ b/src/test/java/io/hexlet/blog/controller/api/PostsCommentsControllerTest.java
@@ -2,6 +2,7 @@ package io.hexlet.blog.controller.api;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -20,11 +21,18 @@ import io.hexlet.blog.repository.PostRepository;
 import io.hexlet.blog.util.ModelGenerator;
 import io.hexlet.blog.util.UserUtils;
 import jakarta.transaction.Transactional;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.nio.charset.StandardCharsets;
 
 @SpringBootTest
 @Transactional
 @AutoConfigureMockMvc
 public class PostsCommentsControllerTest {
+
+    @Autowired
+    private WebApplicationContext wac;
 
     @Autowired
     private MockMvc mockMvc;
@@ -47,7 +55,13 @@ public class PostsCommentsControllerTest {
 
     @BeforeEach
     public void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(wac)
+                .defaultResponseCharacterEncoding(StandardCharsets.UTF_8)
+                .apply(springSecurity())
+                .build();
+
         token = jwt().jwt(builder -> builder.subject("hexlet@example.com"));
+
         testPost = Instancio.of(modelGenerator.getPostModel())
                 .create();
         testPost.setAuthor(userUtils.getTestUser());

--- a/src/test/java/io/hexlet/blog/controller/api/PostsControllerTest.java
+++ b/src/test/java/io/hexlet/blog/controller/api/PostsControllerTest.java
@@ -4,6 +4,7 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -19,6 +20,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.JwtRequestPostProcessor;
+import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -29,10 +31,18 @@ import io.hexlet.blog.model.Post;
 import io.hexlet.blog.repository.PostRepository;
 import io.hexlet.blog.util.ModelGenerator;
 import io.hexlet.blog.util.UserUtils;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.nio.charset.StandardCharsets;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@WebAppConfiguration
 public class PostsControllerTest {
+
+    @Autowired
+    private WebApplicationContext wac;
 
     @Autowired
     private MockMvc mockMvc;
@@ -58,7 +68,13 @@ public class PostsControllerTest {
 
     @BeforeEach
     public void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(wac)
+                .defaultResponseCharacterEncoding(StandardCharsets.UTF_8)
+                .apply(springSecurity())
+                .build();
+
         token = jwt().jwt(builder -> builder.subject("hexlet@example.com"));
+
         testPost = Instancio.of(modelGenerator.getPostModel())
                 .create();
         testPost.setAuthor(userUtils.getTestUser());

--- a/src/test/java/io/hexlet/blog/controller/api/PostsControllerTest.java
+++ b/src/test/java/io/hexlet/blog/controller/api/PostsControllerTest.java
@@ -20,7 +20,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.JwtRequestPostProcessor;
-import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -38,7 +37,6 @@ import java.nio.charset.StandardCharsets;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@WebAppConfiguration
 public class PostsControllerTest {
 
     @Autowired

--- a/src/test/java/io/hexlet/blog/controller/api/UsersControllerTest.java
+++ b/src/test/java/io/hexlet/blog/controller/api/UsersControllerTest.java
@@ -3,11 +3,13 @@ package io.hexlet.blog.controller.api;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
 import org.instancio.Instancio;
@@ -26,10 +28,15 @@ import io.hexlet.blog.model.User;
 import io.hexlet.blog.repository.UserRepository;
 import io.hexlet.blog.util.ModelGenerator;
 import net.datafaker.Faker;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 public class UsersControllerTest {
+
+    @Autowired
+    private WebApplicationContext wac;
 
     @Autowired
     private MockMvc mockMvc;
@@ -52,7 +59,13 @@ public class UsersControllerTest {
 
     @BeforeEach
     public void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(wac)
+                .defaultResponseCharacterEncoding(StandardCharsets.UTF_8)
+                .apply(springSecurity())
+                .build();
+
         token = jwt().jwt(builder -> builder.subject("hexlet@example.com"));
+
         testUser = Instancio.of(modelGenerator.getUserModel())
                 .create();
         userRepository.save(testUser);


### PR DESCRIPTION
В генерируемых строках для тестов используются латинские символы с точками и значками сверху, например: "Jürgen". Такие строки вызывают проблемы если пользоваться кодировкой по умолчанию "ISO-8859-1".

Пример похожей проблемы:
https://github.com/spring-projects/spring-framework/issues/27214


