### PR TITLE
Сравнение объектов в тестах

### DIFF
--- a/src/main/java/io/hexlet/blog/mapper/PostCommentMapper.java
+++ b/src/main/java/io/hexlet/blog/mapper/PostCommentMapper.java
@@ -19,5 +19,9 @@ public abstract class PostCommentMapper {
     @Mapping(source = "author.id", target = "authorId")
     @Mapping(source = "post.id", target = "postId")
     public abstract PostCommentDTO map(PostComment model);
+
+    @Mapping(source = "authorId", target = "author.id")
+    @Mapping(source = "postId", target = "post.id")
+    public abstract PostComment map(PostCommentDTO model);
 }
 

--- a/src/main/java/io/hexlet/blog/mapper/PostMapper.java
+++ b/src/main/java/io/hexlet/blog/mapper/PostMapper.java
@@ -25,5 +25,8 @@ public abstract class PostMapper {
     @Mapping(source = "author.id", target = "authorId")
     public abstract PostDTO map(Post model);
 
+    @Mapping(source = "authorId", target = "author.id")
+    public abstract Post map(PostDTO model);
+
     public abstract void update(PostUpdateDTO dto, @MappingTarget Post model);
 }

--- a/src/main/java/io/hexlet/blog/mapper/UserMapper.java
+++ b/src/main/java/io/hexlet/blog/mapper/UserMapper.java
@@ -35,6 +35,9 @@ public abstract class UserMapper {
     @Mapping(target = "password", ignore = true)
     public abstract UserDTO map(User model);
 
+    @Mapping(target = "email", source = "username")
+    public abstract User map(UserDTO model);
+
     public abstract void update(UserUpdateDTO update, @MappingTarget User destination);
 
     @BeforeMapping

--- a/src/main/java/io/hexlet/blog/repository/PostCommentRepository.java
+++ b/src/main/java/io/hexlet/blog/repository/PostCommentRepository.java
@@ -10,8 +10,13 @@ import org.springframework.stereotype.Repository;
 import io.hexlet.blog.model.Post;
 import io.hexlet.blog.model.PostComment;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface PostCommentRepository extends JpaRepository<PostComment, Long>, JpaSpecificationExecutor<PostComment> {
     // Page<Post> findAll(Specification<Post> spec, Pageable pageable);
+
+    Optional<List<PostComment>> findAllByPostId(Long postId);
 }
 

--- a/src/main/java/io/hexlet/blog/repository/PostCommentRepository.java
+++ b/src/main/java/io/hexlet/blog/repository/PostCommentRepository.java
@@ -10,13 +10,8 @@ import org.springframework.stereotype.Repository;
 import io.hexlet.blog.model.Post;
 import io.hexlet.blog.model.PostComment;
 
-import java.util.List;
-import java.util.Optional;
-
 @Repository
 public interface PostCommentRepository extends JpaRepository<PostComment, Long>, JpaSpecificationExecutor<PostComment> {
     // Page<Post> findAll(Specification<Post> spec, Pageable pageable);
-
-    Optional<List<PostComment>> findAllByPostId(Long postId);
 }
 

--- a/src/test/java/io/hexlet/blog/controller/api/PostsCommentsControllerTest.java
+++ b/src/test/java/io/hexlet/blog/controller/api/PostsCommentsControllerTest.java
@@ -94,8 +94,7 @@ public class PostsCommentsControllerTest {
 
         String body = response.getContentAsString();
 
-        Map<String, Object> content = om.readValue(body, new TypeReference<>() {
-        });
+        Map<String, Object> content = om.readValue(body, new TypeReference<>() {});
 
         Object postComments = content.get("content");
 

--- a/src/test/java/io/hexlet/blog/controller/api/PostsCommentsControllerTest.java
+++ b/src/test/java/io/hexlet/blog/controller/api/PostsCommentsControllerTest.java
@@ -1,6 +1,5 @@
 package io.hexlet.blog.controller.api;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -95,28 +94,17 @@ public class PostsCommentsControllerTest {
 
         String body = response.getContentAsString();
 
-        Map<String, Object> parsedBody = om.readValue(body, new TypeReference<>() {
+        Map<String, Object> content = om.readValue(body, new TypeReference<>() {
         });
 
-        Object content = parsedBody.entrySet().stream()
-                .filter(entry -> entry.getKey().equals("content"))
-                .findFirst().map(Map.Entry::getValue).orElseThrow();
+        Object postComments = content.get("content");
 
-        //сравнение dto не работает!
-        //List<PostCommentDTO> actual = om.convertValue(content, new TypeReference<>() {});
-        //List<PostCommentDTO> expected = postCommentRepository.findAll().stream().map(postCommentMapper::map).toList();
+        List<PostCommentDTO> postCommentDTOS = om.convertValue(postComments, new TypeReference<>() {});
 
-        List<PostCommentDTO> contentDTO = om.convertValue(content, new TypeReference<>() {});
-
-        List<PostComment> actual = contentDTO.stream().map(postCommentMapper::map).toList();
-
+        List<PostComment> actual = postCommentDTOS.stream().map(postCommentMapper::map).toList();
         List<PostComment> expected = postCommentRepository.findAll();
 
         Assertions.assertThat(actual).containsAll(expected);
-        assertThat((actual).size()).isEqualTo(2);
-
-
-//      PostCommentMapper: добавила конвертацию из dto в entity
     }
 
     @Test
@@ -129,30 +117,17 @@ public class PostsCommentsControllerTest {
 
         String body = response.getContentAsString();
 
-        Map<String, Object> parsedBody = om.readValue(body, new TypeReference<>() {
-        });
+        Map<String, Object> content = om.readValue(body, new TypeReference<>() {});
 
-        Object content = parsedBody.entrySet().stream()
-                .filter(entry -> entry.getKey().equals("content"))
-                .findFirst().map(Map.Entry::getValue).orElseThrow();
+        Object postComments = content.get("content");
 
-        List<PostCommentDTO> contentDTO = om.convertValue(content, new TypeReference<>() {});
+        List<PostCommentDTO> postCommentDTOS = om.convertValue(postComments, new TypeReference<>() {});
 
-        List<PostComment> actual = contentDTO.stream().map(postCommentMapper::map).toList();
-
+        List<PostComment> actual = postCommentDTOS.stream().map(postCommentMapper::map).toList();
         List<PostComment> expected = postCommentRepository.findAllByPostId(testPost.getId())
                 .orElseThrow();
 
         Assertions.assertThat(actual).containsAll(expected);
-        assertThat((actual).size()).isEqualTo(1);
-
-//      PostCommentRepository: добавила метод поиска комментариев по id Post'а
-
-
-//        assertThatJson(body)
-//            .node("content")
-//            .isArray()
-//            .hasSize(1);
     }
 }
 

--- a/src/test/java/io/hexlet/blog/controller/api/PostsCommentsControllerTest.java
+++ b/src/test/java/io/hexlet/blog/controller/api/PostsCommentsControllerTest.java
@@ -112,7 +112,7 @@ public class PostsCommentsControllerTest {
 
         var actual = postCommentDTOS.stream().map(postCommentMapper::map).toList();
         var expected = postCommentRepository.findAll();
-        Assertions.assertThat(actual).containsAll(expected);
+        Assertions.assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
     }
 
     @Test

--- a/src/test/java/io/hexlet/blog/controller/api/PostsCommentsControllerTest.java
+++ b/src/test/java/io/hexlet/blog/controller/api/PostsCommentsControllerTest.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.hexlet.blog.dto.PostCommentDTO;
 import io.hexlet.blog.mapper.PostCommentMapper;
-import io.hexlet.blog.model.PostComment;
 import org.assertj.core.api.Assertions;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.BeforeEach;
@@ -107,14 +106,12 @@ public class PostsCommentsControllerTest {
         var body = result.getResponse().getContentAsString();
 
         Map<String, Object> content = om.readValue(body, new TypeReference<>() {});
-
-        Object postComments = content.get("content");
+        var postComments = content.get("content");
 
         List<PostCommentDTO> postCommentDTOS = om.convertValue(postComments, new TypeReference<>() {});
 
-        List<PostComment> actual = postCommentDTOS.stream().map(postCommentMapper::map).toList();
-        List<PostComment> expected = postCommentRepository.findAll();
-
+        var actual = postCommentDTOS.stream().map(postCommentMapper::map).toList();
+        var expected = postCommentRepository.findAll();
         Assertions.assertThat(actual).containsAll(expected);
     }
 

--- a/src/test/java/io/hexlet/blog/controller/api/PostsCommentsControllerTest.java
+++ b/src/test/java/io/hexlet/blog/controller/api/PostsCommentsControllerTest.java
@@ -1,5 +1,6 @@
 package io.hexlet.blog.controller.api;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -30,7 +31,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.nio.charset.StandardCharsets;
-
 import java.util.List;
 import java.util.Map;
 
@@ -101,12 +101,10 @@ public class PostsCommentsControllerTest {
 
     @Test
     public void testIndex() throws Exception {
-        var response = mockMvc.perform(get("/api/posts_comments").with(token))
+        var result = mockMvc.perform(get("/api/posts_comments").with(token))
                 .andExpect(status().isOk())
-                .andReturn()
-                .getResponse();
-
-        String body = response.getContentAsString();
+                .andReturn();
+        var body = result.getResponse().getContentAsString();
 
         Map<String, Object> content = om.readValue(body, new TypeReference<>() {});
 
@@ -122,25 +120,13 @@ public class PostsCommentsControllerTest {
 
     @Test
     public void testFilteredIndex() throws Exception {
-        var response = mockMvc.perform(get("/api/posts_comments?postId="
-                        + testPost.getId()).with(token))
+        var result = mockMvc.perform(get("/api/posts_comments?postId=" + testPost.getId()).with(token))
                 .andExpect(status().isOk())
-                .andReturn()
-                .getResponse();
-
-        String body = response.getContentAsString();
-
-        Map<String, Object> content = om.readValue(body, new TypeReference<>() {});
-
-        Object postComments = content.get("content");
-
-        List<PostCommentDTO> postCommentDTOS = om.convertValue(postComments, new TypeReference<>() {});
-
-        List<PostComment> actual = postCommentDTOS.stream().map(postCommentMapper::map).toList();
-        List<PostComment> expected = postCommentRepository.findAllByPostId(testPost.getId())
-                .orElseThrow();
-
-        Assertions.assertThat(actual).containsAll(expected);
+                .andReturn();
+        var body = result.getResponse().getContentAsString();
+        assertThatJson(body)
+                .node("content")
+                .isArray()
+                .hasSize(1);
     }
 }
-

--- a/src/test/java/io/hexlet/blog/controller/api/PostsCommentsControllerTest.java
+++ b/src/test/java/io/hexlet/blog/controller/api/PostsCommentsControllerTest.java
@@ -1,10 +1,11 @@
 package io.hexlet.blog.controller.api;
 
-import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,6 +21,11 @@ import io.hexlet.blog.repository.PostRepository;
 import io.hexlet.blog.util.ModelGenerator;
 import io.hexlet.blog.util.UserUtils;
 import jakarta.transaction.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 
 @SpringBootTest
 @Transactional
@@ -44,6 +50,10 @@ public class PostsCommentsControllerTest {
     private JwtRequestPostProcessor token;
 
     private Post testPost;
+
+    @Autowired
+    private ObjectMapper om;
+
 
     @BeforeEach
     public void setUp() {
@@ -74,11 +84,20 @@ public class PostsCommentsControllerTest {
         var result = mockMvc.perform(get("/api/posts_comments").with(token))
                 .andExpect(status().isOk())
                 .andReturn();
+
         var body = result.getResponse().getContentAsString();
-        assertThatJson(body)
-            .node("content")
-            .isArray()
-            .hasSize(2);
+
+        var postComment = om.readValue(body, Map.class);
+
+        var content = postComment.get("content");
+
+        assertThat(content).isInstanceOf(ArrayList.class);
+        assertThat(((List<?>) content).size()).isEqualTo(2);
+
+//        assertThatJson(body)
+//            .node("content")
+//            .isArray()
+//            .hasSize(2);
     }
 
     @Test
@@ -87,10 +106,18 @@ public class PostsCommentsControllerTest {
                 .andExpect(status().isOk())
                 .andReturn();
         var body = result.getResponse().getContentAsString();
-        assertThatJson(body)
-            .node("content")
-            .isArray()
-            .hasSize(1);
+
+        var postComment = om.readValue(body, Map.class);
+
+        var content = postComment.get("content");
+
+        assertThat(content).isInstanceOf(ArrayList.class);
+        assertThat(((List<?>) content).size()).isEqualTo(1);
+
+//        assertThatJson(body)
+//            .node("content")
+//            .isArray()
+//            .hasSize(1);
     }
 }
 

--- a/src/test/java/io/hexlet/blog/controller/api/PostsControllerTest.java
+++ b/src/test/java/io/hexlet/blog/controller/api/PostsControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import io.hexlet.blog.dto.PostDTO;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,7 @@ import io.hexlet.blog.model.Post;
 import io.hexlet.blog.repository.PostRepository;
 import io.hexlet.blog.util.ModelGenerator;
 import io.hexlet.blog.util.UserUtils;
+
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -55,6 +57,7 @@ public class PostsControllerTest {
     private JwtRequestPostProcessor token;
 
     private Post testPost;
+
 
     @BeforeEach
     public void setUp() {
@@ -137,11 +140,15 @@ public class PostsControllerTest {
         var result = mockMvc.perform(request)
                 .andExpect(status().isOk())
                 .andReturn();
+
         var body = result.getResponse().getContentAsString();
-        assertThatJson(body).and(
-                v -> v.node("slug").isEqualTo(testPost.getSlug()),
-                v -> v.node("name").isEqualTo(testPost.getName()),
-                v -> v.node("body").isEqualTo(testPost.getBody()));
+
+        PostDTO postDTO = om.readValue(body, PostDTO.class);
+        PostDTO testPostDTO = postMapper.map(testPost);
+
+        assertThat(postDTO.getName()).isEqualTo(testPostDTO.getName());
+        assertThat(postDTO.getSlug()).isEqualTo(testPostDTO.getSlug());
+        assertThat(postDTO.getBody()).isEqualTo(testPostDTO.getBody());
     }
 
     @Test

--- a/src/test/java/io/hexlet/blog/controller/api/PostsControllerTest.java
+++ b/src/test/java/io/hexlet/blog/controller/api/PostsControllerTest.java
@@ -85,35 +85,19 @@ public class PostsControllerTest {
     }
 
     @Test
-    public void testShow() throws Exception {
-        postRepository.save(testPost);
-
-        var request = get("/api/posts/" + testPost.getId()).with(jwt());
-        var result = mockMvc.perform(request)
-                .andExpect(status().isOk())
-                .andReturn();
-        var body = result.getResponse().getContentAsString();
-        assertThatJson(body).and(
-                v -> v.node("slug").isEqualTo(testPost.getSlug()),
-                v -> v.node("name").isEqualTo(testPost.getName()),
-                v -> v.node("body").isEqualTo(testPost.getBody()));
-    }
-
-    @Test
     public void testIndex() throws Exception {
         postRepository.save(testPost);
+
         var response = mockMvc.perform(get("/api/posts").with(token))
                 .andExpect(status().isOk())
                 .andReturn()
                 .getResponse();
-
-        String body = response.getContentAsString();
+        var body = response.getContentAsString();
 
         List<PostDTO> postDTOS = om.readValue(body, new TypeReference<>() {});
 
-        List<Post> actual = postDTOS.stream().map(postMapper::map).toList();
-        List<Post> expected = postRepository.findAll();
-
+        var actual = postDTOS.stream().map(postMapper::map).toList();
+        var expected = postRepository.findAll();
         Assertions.assertThat(actual).containsAll(expected);
     }
 
@@ -170,6 +154,21 @@ public class PostsControllerTest {
 
         var actualPost = postRepository.findById(testPost.getId()).get();
         assertThat(actualPost.getName()).isEqualTo(testPost.getName());
+    }
+
+    @Test
+    public void testShow() throws Exception {
+        postRepository.save(testPost);
+
+        var request = get("/api/posts/" + testPost.getId()).with(jwt());
+        var result = mockMvc.perform(request)
+                .andExpect(status().isOk())
+                .andReturn();
+        var body = result.getResponse().getContentAsString();
+        assertThatJson(body).and(
+                v -> v.node("slug").isEqualTo(testPost.getSlug()),
+                v -> v.node("name").isEqualTo(testPost.getName()),
+                v -> v.node("body").isEqualTo(testPost.getBody()));
     }
 
     @Test

--- a/src/test/java/io/hexlet/blog/controller/api/PostsControllerTest.java
+++ b/src/test/java/io/hexlet/blog/controller/api/PostsControllerTest.java
@@ -98,7 +98,7 @@ public class PostsControllerTest {
 
         var actual = postDTOS.stream().map(postMapper::map).toList();
         var expected = postRepository.findAll();
-        Assertions.assertThat(actual).containsAll(expected);
+        Assertions.assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
     }
 
     @Test

--- a/src/test/java/io/hexlet/blog/controller/api/PostsControllerTest.java
+++ b/src/test/java/io/hexlet/blog/controller/api/PostsControllerTest.java
@@ -89,7 +89,7 @@ public class PostsControllerTest {
         mockMvc.perform(request)
                 .andExpect(status().isCreated());
 
-        var post = postRepository.findBySlug(testPost.getSlug()).get();
+        var post = postRepository.findBySlug(testPost.getSlug()).orElseThrow();
         assertNotNull(post);
         assertThat(post.getName()).isEqualTo(testPost.getName());
     }
@@ -109,7 +109,7 @@ public class PostsControllerTest {
         mockMvc.perform(request)
                 .andExpect(status().isOk());
 
-        testPost = postRepository.findById(testPost.getId()).get();
+        testPost = postRepository.findById(testPost.getId()).orElseThrow();
         assertThat(testPost.getName()).isEqualTo(data.getName().get());
     }
 
@@ -128,7 +128,7 @@ public class PostsControllerTest {
         mockMvc.perform(request)
                 .andExpect(status().isForbidden());
 
-        var actualPost = postRepository.findById(testPost.getId()).get();
+        var actualPost = postRepository.findById(testPost.getId()).orElseThrow();
         assertThat(actualPost.getName()).isEqualTo(testPost.getName());
     }
 

--- a/src/test/java/io/hexlet/blog/controller/api/PostsControllerTest.java
+++ b/src/test/java/io/hexlet/blog/controller/api/PostsControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import io.hexlet.blog.dto.PostCreateDTO;
 import io.hexlet.blog.dto.PostDTO;
 import org.assertj.core.api.Assertions;
 import org.instancio.Instancio;
@@ -109,25 +110,31 @@ public class PostsControllerTest {
 
     @Test
     public void testCreate() throws Exception {
-        var newPostDTO = postMapper.map(Instancio.of(modelGenerator.getPostModel())
-                .create());
+
+        var createDTO = new PostCreateDTO();
+        createDTO.setName("TestNameForPost");
+        createDTO.setBody("TestBodyForPost");
+        createDTO.setSlug("TestSlug");
+        createDTO.setAuthorId(userUtils.getTestUser().getId());
+
 
         var request = post("/api/posts")
                 .with(token)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(om.writeValueAsString(newPostDTO));
+                .content(om.writeValueAsString(createDTO));
 
         mockMvc.perform(request)
                 .andExpect(status().isCreated());
 
-        var actualPost = postRepository.findBySlug(newPostDTO.getSlug()).orElseThrow();
+        var actualPost = postRepository.findBySlug(createDTO.getSlug()).orElseThrow();
 
         assertNotNull(actualPost);
-        assertThat(actualPost.getName()).isEqualTo(newPostDTO.getName());
+        assertThat(actualPost.getName()).isEqualTo(createDTO.getName());
     }
 
     @Test
     public void testUpdate() throws Exception {
+
         var postUpdateDTO = new PostUpdateDTO();
         postUpdateDTO.setName(JsonNullable.of("new name"));
 
@@ -144,6 +151,7 @@ public class PostsControllerTest {
 
     @Test
     public void testUpdateFailed() throws Exception {
+
         var postUpdateDTO = new PostUpdateDTO();
         postUpdateDTO.setName(JsonNullable.of("new name"));
 

--- a/src/test/java/io/hexlet/blog/controller/api/UsersControllerTest.java
+++ b/src/test/java/io/hexlet/blog/controller/api/UsersControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.List;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import io.hexlet.blog.dto.UserCreateDTO;
 import io.hexlet.blog.dto.UserDTO;
 import io.hexlet.blog.dto.UserUpdateDTO;
 import io.hexlet.blog.mapper.UserMapper;
@@ -105,22 +106,26 @@ public class UsersControllerTest {
 
     @Test
     public void testCreate() throws Exception {
-        User newUser = Instancio.of(modelGenerator.getUserModel())
-                .create();
+
+        var createDTO = new UserCreateDTO();
+        createDTO.setEmail("testMail@example.com");
+        createDTO.setPassword("testPassword");
+        createDTO.setFirstName("Alice");
+        createDTO.setLastName("Fox");
 
         var request = post("/api/users")
                 .with(token)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(om.writeValueAsString(newUser));
+                .content(om.writeValueAsString(createDTO));
 
         mockMvc.perform(request)
                 .andExpect(status().isCreated());
 
-        var actualUser = userRepository.findByEmail(newUser.getEmail()).orElseThrow();
+        var actualUser = userRepository.findByEmail(createDTO.getEmail()).orElseThrow();
 
         assertNotNull(actualUser);
-        assertThat(actualUser.getFirstName()).isEqualTo(newUser.getFirstName());
-        assertThat(actualUser.getLastName()).isEqualTo(newUser.getLastName());
+        assertThat(actualUser.getFirstName()).isEqualTo(createDTO.getFirstName());
+        assertThat(actualUser.getLastName()).isEqualTo(createDTO.getLastName());
     }
 
     @Test

--- a/src/test/java/io/hexlet/blog/controller/api/UsersControllerTest.java
+++ b/src/test/java/io/hexlet/blog/controller/api/UsersControllerTest.java
@@ -8,12 +8,13 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import java.util.List;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+
 import com.fasterxml.jackson.core.type.TypeReference;
-import io.hexlet.blog.dto.UserCreateDTO;
 import io.hexlet.blog.dto.UserDTO;
-import io.hexlet.blog.dto.UserUpdateDTO;
 import io.hexlet.blog.mapper.UserMapper;
 import org.assertj.core.api.Assertions;
 import org.instancio.Instancio;
@@ -118,43 +119,38 @@ public class UsersControllerTest {
 
     @Test
     public void testCreate() throws Exception {
-
-        var createDTO = new UserCreateDTO();
-        createDTO.setEmail("testMail@example.com");
-        createDTO.setPassword("testPassword");
-        createDTO.setFirstName("Alice");
-        createDTO.setLastName("Fox");
+        var data = Instancio.of(modelGenerator.getUserModel())
+                .create();
 
         var request = post("/api/users")
                 .with(token)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(om.writeValueAsString(createDTO));
-
+                .content(om.writeValueAsString(data));
         mockMvc.perform(request)
                 .andExpect(status().isCreated());
 
-        var actualUser = userRepository.findByEmail(createDTO.getEmail()).orElseThrow();
+        var user = userRepository.findByEmail(data.getEmail()).get();
 
-        assertNotNull(actualUser);
-        assertThat(actualUser.getFirstName()).isEqualTo(createDTO.getFirstName());
-        assertThat(actualUser.getLastName()).isEqualTo(createDTO.getLastName());
+        assertNotNull(user);
+        assertThat(user.getFirstName()).isEqualTo(data.getFirstName());
+        assertThat(user.getLastName()).isEqualTo(data.getLastName());
     }
 
     @Test
     public void testUpdate() throws Exception {
 
-        var updateDTO = new UserUpdateDTO();
-        updateDTO.setFirstName("Mike");
+        var data = new HashMap<>();
+        data.put("firstName", "Mike");
 
-        var request = put("/api/users/" + testUser.getId()).with(token)
+        var request = put("/api/users/" + testUser.getId())
+                .with(token)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(om.writeValueAsString(updateDTO));
+                .content(om.writeValueAsString(data));
 
         mockMvc.perform(request)
                 .andExpect(status().isOk());
 
-        var actualUser = userRepository.findById(testUser.getId()).orElseThrow();
-
-        assertThat(actualUser.getFirstName()).isEqualTo((updateDTO.getFirstName()));
+        var user = userRepository.findById(testUser.getId()).get();
+        assertThat(user.getFirstName()).isEqualTo(("Mike"));
     }
 }

--- a/src/test/java/io/hexlet/blog/controller/api/UsersControllerTest.java
+++ b/src/test/java/io/hexlet/blog/controller/api/UsersControllerTest.java
@@ -9,7 +9,12 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.HashMap;
+import java.util.List;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.hexlet.blog.dto.UserDTO;
+import io.hexlet.blog.mapper.UserMapper;
+import org.assertj.core.api.Assertions;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,6 +52,9 @@ public class UsersControllerTest {
     @Autowired
     private ObjectMapper om;
 
+    @Autowired
+    private UserMapper userMapper;
+
     private JwtRequestPostProcessor token;
 
     private User testUser;
@@ -61,8 +69,25 @@ public class UsersControllerTest {
 
     @Test
     public void testIndex() throws Exception {
-        mockMvc.perform(get("/api/users").with(jwt()))
-                .andExpect(status().isOk());
+//        mockMvc.perform(get("/api/users").with(jwt()))
+//                .andExpect(status().isOk());
+        var response = mockMvc.perform(get("/api/users").with(jwt()))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse();
+
+        String body = response.getContentAsString();
+
+        List<UserDTO> bodyDTO = om.readValue(body, new TypeReference<>() {
+        });
+        List<User> actual = bodyDTO.stream().map(userMapper::map).toList();
+
+        List<User> expected = userRepository.findAll();
+
+        Assertions.assertThat(actual).containsAll(expected);
+
+
+        //UserMapper: добавила конвертацию из dto в entity
     }
 
     @Test

--- a/src/test/java/io/hexlet/blog/controller/api/UsersControllerTest.java
+++ b/src/test/java/io/hexlet/blog/controller/api/UsersControllerTest.java
@@ -27,6 +27,7 @@ import io.hexlet.blog.repository.UserRepository;
 import io.hexlet.blog.util.ModelGenerator;
 import net.datafaker.Faker;
 
+
 @SpringBootTest
 @AutoConfigureMockMvc
 public class UsersControllerTest {
@@ -76,7 +77,7 @@ public class UsersControllerTest {
         mockMvc.perform(request)
                 .andExpect(status().isCreated());
 
-        var user = userRepository.findByEmail(data.getEmail()).get();
+        var user = userRepository.findByEmail(data.getEmail()).orElseThrow();
 
         assertNotNull(user);
         assertThat(user.getFirstName()).isEqualTo(data.getFirstName());
@@ -97,7 +98,7 @@ public class UsersControllerTest {
         mockMvc.perform(request)
                  .andExpect(status().isOk());
 
-        var user = userRepository.findById(testUser.getId()).get();
+        var user = userRepository.findById(testUser.getId()).orElseThrow();
         assertThat(user.getFirstName()).isEqualTo(("Mike"));
     }
 }

--- a/src/test/java/io/hexlet/blog/controller/api/UsersControllerTest.java
+++ b/src/test/java/io/hexlet/blog/controller/api/UsersControllerTest.java
@@ -94,7 +94,7 @@ public class UsersControllerTest {
 
         var actual = userDTOS.stream().map(userMapper::map).toList();
         var expected = userRepository.findAll();
-        Assertions.assertThat(actual).containsAll(expected);
+        Assertions.assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
     }
 
     @Test


### PR DESCRIPTION
Теперь для сравнения объектов в тестах не требуется работать напрямую с json, а сравнивать java-объекты.

Было:
```java
        var request = get("/api/posts/" + testPost.getId()).with(jwt());
        var result = mockMvc.perform(request)
                .andExpect(status().isOk())
                .andReturn();
        var body = result.getResponse().getContentAsString();
        assertThatJson(body).and(
                v -> v.node("slug").isEqualTo(testPost.getSlug()),
                v -> v.node("name").isEqualTo(testPost.getName()),
                v -> v.node("body").isEqualTo(testPost.getBody()));
```

Стало:
```java
        String body = response.getContentAsString();

        PostDTO postDTO = om.readValue(body, PostDTO.class);
        PostDTO testPostDTO = postMapper.map(testPost);

        assertThat(postDTO.getName()).isEqualTo(testPostDTO.getName());
        assertThat(postDTO.getSlug()).isEqualTo(testPostDTO.getSlug());
        assertThat(postDTO.getBody()).isEqualTo(testPostDTO.getBody());
```
        