### PR TITLE
Deleted @Transactional and added @AfterEach in tests

### DIFF
--- a/src/test/java/io/hexlet/blog/controller/api/PostsCommentsControllerTest.java
+++ b/src/test/java/io/hexlet/blog/controller/api/PostsCommentsControllerTest.java
@@ -112,7 +112,7 @@ public class PostsCommentsControllerTest {
 
         var actual = postCommentDTOS.stream().map(postCommentMapper::map).toList();
         var expected = postCommentRepository.findAll();
-        Assertions.assertThat(actual).containsAll(expected);
+        Assertions.assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
     }
 
     @Test

--- a/src/test/java/io/hexlet/blog/controller/api/PostsCommentsControllerTest.java
+++ b/src/test/java/io/hexlet/blog/controller/api/PostsCommentsControllerTest.java
@@ -1,38 +1,36 @@
 package io.hexlet.blog.controller.api;
 
-import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
-import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.hexlet.blog.dto.PostCommentDTO;
 import io.hexlet.blog.mapper.PostCommentMapper;
+import io.hexlet.blog.model.Post;
 import io.hexlet.blog.model.User;
+import io.hexlet.blog.repository.PostCommentRepository;
+import io.hexlet.blog.repository.PostRepository;
+import io.hexlet.blog.repository.UserRepository;
+import io.hexlet.blog.util.ModelGenerator;
 import org.assertj.core.api.Assertions;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.JwtRequestPostProcessor;
 import org.springframework.test.web.servlet.MockMvc;
-
-import io.hexlet.blog.model.Post;
-import io.hexlet.blog.repository.PostCommentRepository;
-import io.hexlet.blog.repository.PostRepository;
-import io.hexlet.blog.util.ModelGenerator;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
-import io.hexlet.blog.repository.UserRepository;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
 @SpringBootTest
@@ -72,6 +70,10 @@ public class PostsCommentsControllerTest {
 
     @BeforeEach
     public void setUp() {
+        postCommentRepository.deleteAll();
+        postRepository.deleteAll();
+        userRepository.deleteAll();
+
         mockMvc = MockMvcBuilders.webAppContextSetup(wac)
                 .defaultResponseCharacterEncoding(StandardCharsets.UTF_8)
                 .apply(springSecurity())
@@ -100,13 +102,6 @@ public class PostsCommentsControllerTest {
         testPostComment2.setPost(testPost2);
         testPostComment2.setAuthor(testUser);
         postCommentRepository.save(testPostComment2);
-    }
-
-    @AfterEach
-    public void clean() {
-        postCommentRepository.deleteAll();
-        postRepository.deleteAll();
-        userRepository.deleteAll();
     }
 
     @Test

--- a/src/test/java/io/hexlet/blog/controller/api/PostsControllerTest.java
+++ b/src/test/java/io/hexlet/blog/controller/api/PostsControllerTest.java
@@ -98,7 +98,7 @@ public class PostsControllerTest {
 
         var actual = postDTOS.stream().map(postMapper::map).toList();
         var expected = postRepository.findAll();
-        Assertions.assertThat(actual).containsAll(expected);
+        Assertions.assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
     }
 
     @Test

--- a/src/test/java/io/hexlet/blog/controller/api/PostsControllerTest.java
+++ b/src/test/java/io/hexlet/blog/controller/api/PostsControllerTest.java
@@ -13,8 +13,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.hexlet.blog.dto.PostDTO;
+import io.hexlet.blog.model.User;
+import io.hexlet.blog.repository.UserRepository;
 import org.assertj.core.api.Assertions;
 import org.instancio.Instancio;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openapitools.jackson.nullable.JsonNullable;
@@ -32,7 +35,6 @@ import io.hexlet.blog.mapper.PostMapper;
 import io.hexlet.blog.model.Post;
 import io.hexlet.blog.repository.PostRepository;
 import io.hexlet.blog.util.ModelGenerator;
-import io.hexlet.blog.util.UserUtils;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -63,11 +65,13 @@ public class PostsControllerTest {
     private PostRepository postRepository;
 
     @Autowired
-    private UserUtils userUtils;
+    private UserRepository userRepository;
 
     private JwtRequestPostProcessor token;
 
     private Post testPost;
+
+    private User testUser;
 
 
     @BeforeEach
@@ -77,11 +81,19 @@ public class PostsControllerTest {
                 .apply(springSecurity())
                 .build();
 
-        token = jwt().jwt(builder -> builder.subject("hexlet@example.com"));
+        testUser = Instancio.of(modelGenerator.getUserModel()).create();
+        userRepository.save(testUser);
+        token = jwt().jwt(builder -> builder.subject(testUser.getEmail()));
 
         testPost = Instancio.of(modelGenerator.getPostModel())
                 .create();
-        testPost.setAuthor(userUtils.getTestUser());
+        testPost.setAuthor(testUser);
+    }
+
+    @AfterEach
+    public void clean() {
+        postRepository.deleteAll();
+        userRepository.deleteAll();
     }
 
     @Test

--- a/src/test/java/io/hexlet/blog/controller/api/UsersControllerTest.java
+++ b/src/test/java/io/hexlet/blog/controller/api/UsersControllerTest.java
@@ -19,6 +19,7 @@ import io.hexlet.blog.dto.UserDTO;
 import io.hexlet.blog.mapper.UserMapper;
 import org.assertj.core.api.Assertions;
 import org.instancio.Instancio;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -75,11 +76,14 @@ public class UsersControllerTest {
                 .apply(springSecurity())
                 .build();
 
-        token = jwt().jwt(builder -> builder.subject("hexlet@example.com"));
-
-        testUser = Instancio.of(modelGenerator.getUserModel())
-                .create();
+        testUser = Instancio.of(modelGenerator.getUserModel()).create();
         userRepository.save(testUser);
+        token = jwt().jwt(builder -> builder.subject(testUser.getEmail()));
+    }
+
+    @AfterEach
+    public void clean() {
+        userRepository.deleteAll();
     }
 
     @Test

--- a/src/test/java/io/hexlet/blog/controller/api/UsersControllerTest.java
+++ b/src/test/java/io/hexlet/blog/controller/api/UsersControllerTest.java
@@ -1,5 +1,30 @@
 package io.hexlet.blog.controller.api;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.hexlet.blog.dto.UserDTO;
+import io.hexlet.blog.mapper.UserMapper;
+import io.hexlet.blog.model.User;
+import io.hexlet.blog.repository.UserRepository;
+import io.hexlet.blog.util.ModelGenerator;
+import net.datafaker.Faker;
+import org.assertj.core.api.Assertions;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.JwtRequestPostProcessor;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -9,34 +34,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.List;
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import io.hexlet.blog.dto.UserDTO;
-import io.hexlet.blog.mapper.UserMapper;
-import org.assertj.core.api.Assertions;
-import org.instancio.Instancio;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.MediaType;
-import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.JwtRequestPostProcessor;
-import org.springframework.test.web.servlet.MockMvc;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import io.hexlet.blog.model.User;
-import io.hexlet.blog.repository.UserRepository;
-import io.hexlet.blog.util.ModelGenerator;
-import net.datafaker.Faker;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
 
 
 @SpringBootTest
@@ -71,6 +68,8 @@ public class UsersControllerTest {
 
     @BeforeEach
     public void setUp() {
+        userRepository.deleteAll();
+
         mockMvc = MockMvcBuilders.webAppContextSetup(wac)
                 .defaultResponseCharacterEncoding(StandardCharsets.UTF_8)
                 .apply(springSecurity())
@@ -79,11 +78,6 @@ public class UsersControllerTest {
         testUser = Instancio.of(modelGenerator.getUserModel()).create();
         userRepository.save(testUser);
         token = jwt().jwt(builder -> builder.subject(testUser.getEmail()));
-    }
-
-    @AfterEach
-    public void clean() {
-        userRepository.deleteAll();
     }
 
     @Test
@@ -113,7 +107,7 @@ public class UsersControllerTest {
         mockMvc.perform(request)
                 .andExpect(status().isCreated());
 
-        var user = userRepository.findByEmail(data.getEmail()).get();
+        var user = userRepository.findByEmail(data.getEmail()).orElseThrow();
 
         assertNotNull(user);
         assertThat(user.getFirstName()).isEqualTo(data.getFirstName());
@@ -134,7 +128,7 @@ public class UsersControllerTest {
         mockMvc.perform(request)
                 .andExpect(status().isOk());
 
-        var user = userRepository.findById(testUser.getId()).get();
+        var user = userRepository.findById(testUser.getId()).orElseThrow();
         assertThat(user.getFirstName()).isEqualTo(("Mike"));
     }
 

--- a/src/test/java/io/hexlet/blog/controller/api/UsersControllerTest.java
+++ b/src/test/java/io/hexlet/blog/controller/api/UsersControllerTest.java
@@ -94,7 +94,7 @@ public class UsersControllerTest {
 
         var actual = userDTOS.stream().map(userMapper::map).toList();
         var expected = userRepository.findAll();
-        Assertions.assertThat(actual).containsAll(expected);
+        Assertions.assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
     }
 
     @Test


### PR DESCRIPTION
Приветствую!
Когда в тесте используется @Transactional, то в классах доменных моделей будут загружены и поля с ленивой загрузкой, т.е. там, где потенциально могло вылететь исключение LazyInitializationException, оно не вылетет, и тест покажет ложный результат.
Есть и другие возможные проблемы, подробнее:
https://dev.to/henrykeys/don-t-use-transactional-in-tests-40eb

Рекомендуется писать тесты без @Transactional и удалять данные вручную или использовать расширения.

```java
@AfterEach
public void clean() {
    postCommentRepository.deleteAll();
    postRepository.deleteAll();
    userRepository.deleteAll();
}
```