### PR TITLE
Замена @Autowired на @PersistenceContext

### DIFF
--- a/src/main/java/io/hexlet/blog/mapper/ReferenceMapper.java
+++ b/src/main/java/io/hexlet/blog/mapper/ReferenceMapper.java
@@ -1,18 +1,17 @@
 package io.hexlet.blog.mapper;
 
+import io.hexlet.blog.model.BaseEntity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingConstants;
 import org.mapstruct.TargetType;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import io.hexlet.blog.model.BaseEntity;
-import jakarta.persistence.EntityManager;
 
 @Mapper(
     componentModel = MappingConstants.ComponentModel.SPRING
 )
 public abstract class ReferenceMapper {
-    @Autowired
+    @PersistenceContext
     private EntityManager entityManager;
 
     public <T extends BaseEntity> T toEntity(Long id, @TargetType Class<T> entityClass) {


### PR DESCRIPTION
Не стоит использовать @Autowired потому, что он создает только один экземпляр EntityManager для всего приложения. @PersistenceContext создает новый экземпляр EntityManager для каждой транзакции.
Подробнее:
https://stackoverflow.com/questions/31335211/autowired-vs-persistencecontext-for-entitymanager-bean